### PR TITLE
fix(conway): Fix Play/Pause switch no longer working

### DIFF
--- a/front/src/components/Conway/Side.tsx
+++ b/front/src/components/Conway/Side.tsx
@@ -61,7 +61,7 @@ export const Side = ({
       <Switch
         size="lg"
         color="primary"
-        onClick={() => {
+        onChange={() => {
           setIsPlaying(!isPlaying);
         }}
         aria-label={isPlaying ? 'Pause' : 'Play'}


### PR DESCRIPTION
Seems like heroUI broke the Switch API at some point. `OnClick` doesn't trigger anything anymore, we need to use `onChange` 